### PR TITLE
fix 'NaN' column bug

### DIFF
--- a/server/main/shares.js
+++ b/server/main/shares.js
@@ -161,7 +161,7 @@ const Shares = function (logger, client, config, configMain) {
     const identifier = shareData.identifier || 'master';
     const times = (Object.keys(workerData).length >= 1 && shareType === 'valid') ?
       _this.handleTimes(workerData) : 0;
-    const current = shareType === 'valid' ? shareData.difficulty : -shareData.difficulty;
+    const current = shareType === 'valid' ? shareData.difficulty : 0;
 
     // Return Round Updates
     return {

--- a/server/test/shares.test.js
+++ b/server/test/shares.test.js
@@ -373,7 +373,7 @@ describe('Test shares functionality', () => {
       times: 0,
       type: 'primary',
       valid: 0,
-      work: -1,
+      work: 0,
     };
     expect(shares.handleCurrentRounds(null, workerData, shareData, 'invalid', false, 'primary')).toStrictEqual(expected);
   });
@@ -398,7 +398,7 @@ describe('Test shares functionality', () => {
       times: 0,
       type: 'primary',
       valid: 0,
-      work: -1,
+      work: 0,
     };
     expect(shares.handleCurrentRounds(null, workerData, shareData, 'stale', false, 'primary')).toStrictEqual(expected);
   });


### PR DESCRIPTION
So once every often checks call an error about a nan column or whatever. The issue is that stratum.handleValidation called from stratum.handlePrimaryWorkers during Round processing can throw an error in certain circumstances.

Take a round in which one worker submits one valid and one invalid share with the same difficulty and finds a block with the valid one. You get 1 share, 1 block, 0 work, 0 total work. handleValidations tries to calculate the proportion of the reward, tries to get a result of 0/0 and returns a NaN. This then passes all the way up to a db insert..